### PR TITLE
Try to build with `repo2jupyterlite`

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
  - matplotlib
  - ipywidgets
  # - jupyter
- - jupyterlab
+ # - jupyterlab
  - pip:
    - segyio
    - tqdm

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
  - scipy
  - matplotlib
  - ipywidgets
- - jupyter
+ # - jupyter
  - jupyterlab
  - pip:
    - segyio

--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,7 @@
 name: seg-tutorial-phase
 channels:
+  - https://repo.mamba.pm/emscripten-forge
   - conda-forge
-  - defaults
 dependencies:
  - pip
  - numpy

--- a/environment.yml
+++ b/environment.yml
@@ -10,6 +10,5 @@ dependencies:
  - ipywidgets
  # - jupyter
  # - jupyterlab
- - pip:
-   - segyio
-   - tqdm
+ - segyio
+ - tqdm


### PR DESCRIPTION
Attempts at building the repo with `repo2jupyterlite`: https://github.com/jupyterlite/repo2jupyterlite/issues/9

Specifying `segyio` in `pip` gives the following error: 

```
RuntimeError: Cannot install binary PyPI package, only pure Python packages are supported
```

However `segyio` is not available on `emscripten-forge` (yet):

![image](https://github.com/stevejpurves/seg_tutorial/assets/591645/61a608e8-4fbc-429d-979a-b2e73106d0cd)
